### PR TITLE
Add marketing trial upload UI

### DIFF
--- a/src/app/api/backend.ts
+++ b/src/app/api/backend.ts
@@ -1,0 +1,22 @@
+export const BACKEND_API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  'https://jhmyrcpav9.execute-api.us-east-1.amazonaws.com/dev';
+
+export const proxyJsonPost = async (path: string, body: unknown) => {
+  const response = await fetch(`${BACKEND_API_BASE_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    cache: 'no-store',
+  });
+
+  const text = await response.text();
+  const contentType = response.headers.get('content-type') || 'application/json';
+
+  return new Response(text, {
+    status: response.status,
+    headers: {
+      'Content-Type': contentType,
+    },
+  });
+};

--- a/src/app/api/shared-video-details/route.ts
+++ b/src/app/api/shared-video-details/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest } from 'next/server';
+import { proxyJsonPost } from '../backend';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  return proxyJsonPost('/get-shared-video-details', body);
+}

--- a/src/app/api/trial-upload/complete/route.ts
+++ b/src/app/api/trial-upload/complete/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest } from 'next/server';
+import { proxyJsonPost } from '../../backend';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  return proxyJsonPost('/trial-upload/complete', body);
+}

--- a/src/app/api/trial-upload/start/route.ts
+++ b/src/app/api/trial-upload/start/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest } from 'next/server';
+import { proxyJsonPost } from '../../backend';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  return proxyJsonPost('/trial-upload/start', body);
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import Image from 'next/image';
+import Link from 'next/link';
 import React, { useState, useEffect } from 'react';
 
 export default function LandingPage() {
@@ -128,8 +129,39 @@ export default function LandingPage() {
                 Don&apos;t whiff on hitting your potential<br /> 
                 Record, Get AI Tips, and Show Off to Coaches
               </p>
+              <div className="mt-8 flex flex-col items-end gap-3 sm:flex-row sm:justify-end">
+                <Link
+                  href="/try"
+                  className="inline-flex items-center justify-center rounded-md bg-orange-600 px-6 py-3 text-base font-bold text-white shadow-lg transition-colors hover:bg-orange-700"
+                >
+                  Try a Free Swing Upload
+                </Link>
+                <a
+                  href="#benefits-section"
+                  className="inline-flex items-center justify-center rounded-md bg-white px-6 py-3 text-base font-bold text-blue-700 shadow-lg transition-colors hover:bg-gray-100"
+                >
+                  See How It Works
+                </a>
+              </div>
             </div>
           </div>
+        </div>
+      </section>
+
+      <section className="bg-gray-950 px-6 py-6 text-white">
+        <div className="container mx-auto flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-2xl font-bold">Want to see your own swing?</h2>
+            <p className="mt-1 text-gray-300">
+              Upload one short clip and get a public trial result with video, computer vision, and AI feedback.
+            </p>
+          </div>
+          <Link
+            href="/try"
+            className="inline-flex items-center justify-center rounded-md bg-orange-600 px-5 py-3 font-bold text-white hover:bg-orange-700"
+          >
+            Start Free Trial Upload
+          </Link>
         </div>
       </section>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -137,31 +137,14 @@ export default function LandingPage() {
                   Try a Free Swing Upload
                 </Link>
                 <a
-                  href="#benefits-section"
+                  href="https://apple.co/3Js2maF"
                   className="inline-flex items-center justify-center rounded-md bg-white px-6 py-3 text-base font-bold text-blue-700 shadow-lg transition-colors hover:bg-gray-100"
                 >
-                  See How It Works
+                  Download Now
                 </a>
               </div>
             </div>
           </div>
-        </div>
-      </section>
-
-      <section className="bg-gray-950 px-6 py-6 text-white">
-        <div className="container mx-auto flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div>
-            <h2 className="text-2xl font-bold">Want to see your own swing?</h2>
-            <p className="mt-1 text-gray-300">
-              Upload one short clip and get a public trial result with video, computer vision, and AI feedback.
-            </p>
-          </div>
-          <Link
-            href="/try"
-            className="inline-flex items-center justify-center rounded-md bg-orange-600 px-5 py-3 font-bold text-white hover:bg-orange-700"
-          >
-            Start Free Trial Upload
-          </Link>
         </div>
       </section>
 

--- a/src/app/try/[shareId]/page.tsx
+++ b/src/app/try/[shareId]/page.tsx
@@ -1,0 +1,360 @@
+'use client';
+
+import Header from '../../../components/Header';
+import Footer from '../../../components/Footer';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ScorecardMetric,
+  TrialVideoDetails,
+  fetchTrialVideoDetails,
+} from '../../../lib/trialApi';
+
+const POLL_INTERVAL_MS = 10000;
+
+const metricLabels: Record<string, string> = {
+  handPath: 'Hand Path',
+  stride: 'Stride',
+  headPosition: 'Head Position',
+  hipRotation: 'Hip Rotation',
+  shoulderHipHandTiming: 'Shoulder, Hip, Hand Timing',
+  followThrough: 'Follow Through',
+  powerGeneration: 'Power Generation',
+};
+
+const metricCriteria: Record<string, string> = {
+  handPath: 'How efficiently the hands move to the ball, stay connected, and avoid casting or looping away from the swing path.',
+  stride: 'How the hitter loads and lands, including balance, timing, direction, and whether the stride supports an athletic launch position.',
+  headPosition: 'How steady the head and eyes remain through load, launch, contact, and follow-through.',
+  hipRotation: 'How well the hips initiate and rotate through the swing while maintaining control and direction.',
+  shoulderHipHandTiming: 'How the lower body, torso, and hands sequence together so energy transfers cleanly into the barrel.',
+  followThrough: 'How the hitter finishes the swing with extension, balance, and a complete path through the hitting zone.',
+  powerGeneration: 'How effectively the swing creates and transfers force from the ground through the body into the bat.',
+};
+
+const formatDateTime = (value?: string | null) => {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+};
+
+const formatMetricLabel = (key: string) =>
+  metricLabels[key] || key.replace(/([A-Z])/g, ' $1').replace(/^./, (char) => char.toUpperCase());
+
+const cleanSummaryFeedback = (summary: string) =>
+  summary
+    .replace(/^(summaryFeedback|summary feedback)\s*:\s*/i, '')
+    .replace(/\n(summaryFeedback|summary feedback)\s*:\s*/gi, '\n')
+    .trim();
+
+const clampPercent = (score: number) => Math.min(100, Math.max(0, (score / 5) * 100));
+
+const getAverageScore = (scorecard: Record<string, ScorecardMetric> | null) => {
+  if (!scorecard) return null;
+  const scores = Object.values(scorecard)
+    .map((metric) => Number(metric.score))
+    .filter((score) => Number.isFinite(score));
+
+  if (!scores.length) return null;
+
+  return scores.reduce((sum, score) => sum + score, 0) / scores.length;
+};
+
+export default function TrialResultPage() {
+  const params = useParams();
+  const shareId = Array.isArray(params.shareId) ? params.shareId[0] : params.shareId;
+  const [details, setDetails] = useState<TrialVideoDetails | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showSkeleton, setShowSkeleton] = useState(false);
+  const [activeInfoKey, setActiveInfoKey] = useState<string | null>(null);
+  const [videoError, setVideoError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  useEffect(() => {
+    if (!shareId) {
+      setError('Missing trial result identifier.');
+      return;
+    }
+
+    let isMounted = true;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const loadDetails = async () => {
+      try {
+        const nextDetails = await fetchTrialVideoDetails(shareId);
+        if (!isMounted) return;
+
+        setDetails(nextDetails);
+        setLastUpdated(new Date());
+        setError(null);
+
+        const isReady =
+          nextDetails.videoStatus === 'Processed' &&
+          Boolean(nextDetails.skeletonUrl) &&
+          Boolean(nextDetails.thumbnailUrl) &&
+          Boolean(nextDetails.aiSummary);
+
+        if (!isReady) {
+          timeoutId = setTimeout(loadDetails, POLL_INTERVAL_MS);
+        }
+      } catch (detailsError) {
+        if (!isMounted) return;
+        setError(
+          detailsError instanceof Error
+            ? detailsError.message
+            : 'Unable to load this trial result.'
+        );
+      }
+    };
+
+    loadDetails();
+
+    return () => {
+      isMounted = false;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [shareId]);
+
+  const scoreEntries = useMemo(
+    () => Object.entries(details?.aiScorecard || {}),
+    [details?.aiScorecard]
+  );
+  const averageScore = getAverageScore(details?.aiScorecard || null);
+  const isProcessed = details?.videoStatus === 'Processed';
+  const hasSkeleton = Boolean(details?.skeletonUrl);
+  const activeVideoUrl = showSkeleton && details?.skeletonUrl ? details.skeletonUrl : details?.videoUrl;
+  const activeVideoType = showSkeleton && details?.skeletonUrl ? 'video/mp4' : undefined;
+  const summaryFeedback = details?.aiSummary ? cleanSummaryFeedback(details.aiSummary) : null;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-gray-950 text-white">
+      <Header />
+      <main className="flex-grow">
+        <section className="border-b border-gray-800 bg-gray-900">
+          <div className="container mx-auto flex flex-col gap-4 px-6 py-6 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-wide text-orange-300">
+                DingerZone trial result
+              </p>
+              <h1 className="mt-1 text-3xl font-bold">Swing Analysis</h1>
+              <p className="mt-2 text-sm text-gray-300">
+                {details?.publicExpiresAt || details?.expirationTime
+                  ? `Public link expires ${formatDateTime(details.publicExpiresAt || details.expirationTime)}.`
+                  : 'Processing usually takes a few minutes.'}
+              </p>
+            </div>
+
+            <Link
+              href="/try"
+              className="inline-flex items-center justify-center rounded-md bg-orange-600 px-5 py-3 font-bold text-white hover:bg-orange-700"
+            >
+              Analyze Another Swing
+            </Link>
+          </div>
+        </section>
+
+        <div className="container mx-auto px-6 py-8">
+          {error && !details && (
+            <div className="rounded-lg border border-red-800 bg-red-950 p-5 text-red-100">
+              <h2 className="mb-2 text-xl font-bold">Result unavailable</h2>
+              <p>{error}</p>
+            </div>
+          )}
+
+          {!details && !error && (
+            <div className="rounded-lg border border-gray-800 bg-gray-900 p-5">
+              <div className="h-5 w-44 animate-pulse rounded bg-gray-700" />
+              <div className="mt-4 aspect-video w-full animate-pulse rounded-lg bg-gray-800" />
+            </div>
+          )}
+
+          {details && (
+            <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+              <section>
+                <div className="mb-4 rounded-lg border border-gray-800 bg-gray-900 p-4">
+                  <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <h2 className="text-xl font-bold">
+                        {details.playerName || 'Public Trial Swing'}
+                      </h2>
+                      <p className="text-sm text-gray-400">
+                        Uploaded {formatDateTime(details.uploadDate) || 'recently'}
+                      </p>
+                    </div>
+
+                    <div className="flex items-center gap-3">
+                      <span className="text-sm text-gray-300">Original</span>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setVideoError(null);
+                          setShowSkeleton((current) => !current);
+                        }}
+                        disabled={!hasSkeleton}
+                        className={`relative h-7 w-12 rounded-full transition-colors ${
+                          showSkeleton && hasSkeleton ? 'bg-blue-600' : 'bg-gray-700'
+                        } disabled:cursor-not-allowed disabled:opacity-50`}
+                        aria-label="Toggle computer vision video"
+                      >
+                        <span
+                          className={`absolute left-1 top-1 h-5 w-5 rounded-full bg-white transition-transform ${
+                            showSkeleton && hasSkeleton ? 'translate-x-5' : 'translate-x-0'
+                          }`}
+                        />
+                      </button>
+                      <span className="text-sm text-gray-300">Computer Vision</span>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="overflow-hidden rounded-lg bg-black">
+                  {activeVideoUrl ? (
+                    <video
+                      key={activeVideoUrl}
+                      controls
+                      preload="metadata"
+                      poster={details.thumbnailUrl || undefined}
+                      playsInline
+                      className="aspect-video w-full object-contain"
+                      onError={(event) => {
+                        const mediaError = event.currentTarget.error;
+                        console.error('Video playback error', {
+                          mode: showSkeleton ? 'skeleton' : 'original',
+                          code: mediaError?.code,
+                          message: mediaError?.message,
+                          url: activeVideoUrl,
+                        });
+                        setVideoError(
+                          showSkeleton
+                            ? 'Computer vision video is not playable yet. Try switching back to Original, then retry in a moment.'
+                            : 'Original video is not playable yet. Try refreshing this result in a moment.'
+                        );
+                      }}
+                    >
+                      <source src={activeVideoUrl} type={activeVideoType} />
+                    </video>
+                  ) : (
+                    <div className="flex aspect-video items-center justify-center bg-gray-900 text-gray-400">
+                      Video is preparing...
+                    </div>
+                  )}
+                </div>
+
+                {videoError && (
+                  <div className="mt-4 rounded-lg border border-yellow-700 bg-yellow-950 p-4 text-sm text-yellow-100">
+                    <p>{videoError}</p>
+                  </div>
+                )}
+
+                {!isProcessed && (
+                  <div className="mt-4 rounded-lg border border-blue-800 bg-blue-950 p-4 text-blue-100">
+                    <h2 className="font-bold">Analysis in progress</h2>
+                    <p className="mt-1 text-sm">
+                      We are checking for the processed video, thumbnail, and AI feedback every 10 seconds.
+                      {lastUpdated ? ` Last checked ${formatDateTime(lastUpdated.toISOString())}.` : ''}
+                    </p>
+                  </div>
+                )}
+              </section>
+
+              <section className="space-y-4">
+                <div className="rounded-lg border border-gray-800 bg-gray-900 p-5">
+                  <div className="flex items-center justify-between gap-4">
+                    <h2 className="text-xl font-bold">Overall</h2>
+                    <span className="text-lg font-bold text-orange-300">
+                      {averageScore ? `${averageScore.toFixed(1)}/5.0` : 'Pending'}
+                    </span>
+                  </div>
+                  <div className="mt-4 h-2 rounded-full bg-gradient-to-r from-red-500 via-yellow-400 to-green-500">
+                    {averageScore && (
+                      <div
+                        className="relative h-2"
+                        style={{ width: `${clampPercent(averageScore)}%` }}
+                      >
+                        <span className="absolute right-0 top-1/2 h-4 w-4 -translate-y-1/2 translate-x-1/2 rounded-full bg-white shadow" />
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {summaryFeedback && (
+                  <div className="rounded-lg border border-gray-800 bg-gray-900 p-5">
+                    <h2 className="text-xl font-bold">Summary Feedback</h2>
+                    <p className="mt-3 whitespace-pre-line text-sm leading-6 text-gray-300">
+                      {summaryFeedback}
+                    </p>
+                  </div>
+                )}
+
+                {scoreEntries.length > 0 ? (
+                  <div className="space-y-3">
+                    {scoreEntries.map(([key, metric]) => (
+                      <div key={key} className="rounded-lg border border-gray-800 bg-gray-900 p-4">
+                        <div className="flex items-center justify-between gap-4">
+                          <div className="relative flex items-center gap-2">
+                            <h3 className="font-bold">{formatMetricLabel(key)}</h3>
+                            <button
+                              type="button"
+                              className="group flex h-5 w-5 items-center justify-center rounded-full border border-gray-500 text-xs font-bold text-gray-300 transition-colors hover:border-blue-300 hover:text-blue-200"
+                              aria-label={`${formatMetricLabel(key)} criteria`}
+                              aria-expanded={activeInfoKey === key}
+                              onClick={() =>
+                                setActiveInfoKey((current) => (current === key ? null : key))
+                              }
+                              onBlur={() => setActiveInfoKey(null)}
+                            >
+                              i
+                              <span
+                                className={`pointer-events-none absolute left-0 top-7 z-20 w-72 rounded-md border border-gray-700 bg-gray-950 p-3 text-left text-xs font-normal leading-5 text-gray-200 shadow-xl ${
+                                  activeInfoKey === key
+                                    ? 'block'
+                                    : 'hidden group-hover:block group-focus:block'
+                                }`}
+                              >
+                                {metricCriteria[key] || 'How strongly this part of the swing supports a repeatable, balanced, and powerful move.'}
+                              </span>
+                            </button>
+                          </div>
+                          <span className="text-sm font-semibold text-gray-200">
+                            {Number(metric.score).toFixed(1)}/5.0
+                          </span>
+                        </div>
+                        <div className="mt-3 h-2 rounded-full bg-gradient-to-r from-red-500 via-yellow-400 to-green-500">
+                          <div
+                            className="relative h-2"
+                            style={{ width: `${clampPercent(Number(metric.score))}%` }}
+                          >
+                            <span className="absolute right-0 top-1/2 h-4 w-4 -translate-y-1/2 translate-x-1/2 rounded-full bg-white shadow" />
+                          </div>
+                        </div>
+                        <p className="mt-3 text-sm leading-6 text-gray-400">{metric.description}</p>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-gray-800 bg-gray-900 p-5 text-gray-300">
+                    Scorecard is still processing.
+                  </div>
+                )}
+
+                {details.retentionExpiresAt && (
+                  <p className="text-xs text-gray-500">
+                    You opted out of model-improvement retention. Stored trial content is scheduled for deletion after {formatDateTime(details.retentionExpiresAt)}.
+                  </p>
+                )}
+              </section>
+            </div>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/try/page.tsx
+++ b/src/app/try/page.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import Header from '../../components/Header';
+import Footer from '../../components/Footer';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
+import {
+  startTrialUpload,
+  uploadTrialFile,
+  completeTrialUpload,
+  isVideoFile,
+} from '../../lib/trialApi';
+
+const MAX_DURATION_SECONDS = 10;
+const FALLBACK_MAX_UPLOAD_BYTES = 75 * 1024 * 1024;
+
+const formatBytes = (bytes: number) => {
+  const mb = bytes / (1024 * 1024);
+  return `${mb.toFixed(mb >= 10 ? 0 : 1)} MB`;
+};
+
+const getVideoDuration = (file: File) =>
+  new Promise<number>((resolve, reject) => {
+    const video = document.createElement('video');
+    const objectUrl = URL.createObjectURL(file);
+
+    video.preload = 'metadata';
+    video.onloadedmetadata = () => {
+      URL.revokeObjectURL(objectUrl);
+      resolve(video.duration);
+    };
+    video.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error('Unable to read video duration.'));
+    };
+    video.src = objectUrl;
+  });
+
+export default function TrialUploadPage() {
+  const router = useRouter();
+  const [file, setFile] = useState<File | null>(null);
+  const [duration, setDuration] = useState<number | null>(null);
+  const [durationWarning, setDurationWarning] = useState<string | null>(null);
+  const [consent, setConsent] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [step, setStep] = useState<'idle' | 'starting' | 'uploading' | 'completing'>('idle');
+  const [maxUploadBytes, setMaxUploadBytes] = useState(FALLBACK_MAX_UPLOAD_BYTES);
+
+  const previewUrl = useMemo(() => {
+    if (!file) return null;
+    return URL.createObjectURL(file);
+  }, [file]);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = event.target.files?.[0] || null;
+    setFile(selectedFile);
+    setDuration(null);
+    setDurationWarning(null);
+    setError(null);
+
+    if (!selectedFile) return;
+
+    if (!isVideoFile(selectedFile)) {
+      setError('Please choose a video file.');
+      return;
+    }
+
+    if (selectedFile.size > maxUploadBytes) {
+      setError(`Please choose a video under ${formatBytes(maxUploadBytes)}.`);
+      return;
+    }
+
+    try {
+      const videoDuration = await getVideoDuration(selectedFile);
+      setDuration(videoDuration);
+      if (videoDuration > MAX_DURATION_SECONDS) {
+        setDurationWarning(
+          `This clip is ${videoDuration.toFixed(1)} seconds. Short clips under ${MAX_DURATION_SECONDS} seconds process best.`
+        );
+      }
+    } catch {
+      setDurationWarning('We could not verify the clip length, but you can still try the upload.');
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!file || isUploading) return;
+
+    if (!isVideoFile(file)) {
+      setError('Please choose a video file.');
+      return;
+    }
+
+    if (file.size > maxUploadBytes) {
+      setError(`Please choose a video under ${formatBytes(maxUploadBytes)}.`);
+      return;
+    }
+
+    setIsUploading(true);
+    setError(null);
+
+    try {
+      setStep('starting');
+      const startResponse = await startTrialUpload({
+        file,
+        modelImprovementConsent: consent,
+      });
+      setMaxUploadBytes(startResponse.maxUploadBytes || FALLBACK_MAX_UPLOAD_BYTES);
+
+      setStep('uploading');
+      await uploadTrialFile({ file, startResponse });
+
+      setStep('completing');
+      const completeResponse = await completeTrialUpload(startResponse.trialId);
+
+      router.push(`/try/${completeResponse.shareId}`);
+    } catch (uploadError) {
+      setError(
+        uploadError instanceof Error
+          ? uploadError.message
+          : 'Upload failed. Please try again.'
+      );
+      setStep('idle');
+      setIsUploading(false);
+    }
+  };
+
+  const uploadButtonLabel = {
+    idle: 'Upload Swing',
+    starting: 'Preparing Upload...',
+    uploading: 'Uploading Video...',
+    completing: 'Starting Analysis...',
+  }[step];
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white text-gray-900">
+      <Header />
+      <main className="flex-grow">
+        <section className="bg-gray-950 text-white">
+          <div className="container mx-auto grid gap-8 px-6 py-10 lg:grid-cols-[0.9fr_1.1fr] lg:items-center lg:py-14">
+            <div>
+              <p className="mb-3 text-sm font-semibold uppercase tracking-wide text-orange-300">
+                Free swing analysis preview
+              </p>
+              <h1 className="mb-4 text-4xl font-bold leading-tight md:text-5xl">
+                Try DingerZone with one swing clip
+              </h1>
+              <p className="text-lg text-gray-200">
+                Upload a short baseball swing video and we will process it with the same AI feedback engine used in the app.
+              </p>
+            </div>
+
+            <form
+              onSubmit={handleSubmit}
+              className="rounded-lg border border-gray-700 bg-gray-900 p-5 shadow-xl"
+            >
+              <label className="block">
+                <span className="mb-2 block text-sm font-semibold text-gray-200">
+                  Swing video
+                </span>
+                <input
+                  type="file"
+                  accept="video/*"
+                  onChange={handleFileChange}
+                  disabled={isUploading}
+                  className="block w-full rounded-md border border-gray-600 bg-gray-950 px-3 py-3 text-sm text-gray-100 file:mr-4 file:rounded-md file:border-0 file:bg-blue-600 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:file:bg-blue-700"
+                />
+              </label>
+
+              {file && (
+                <div className="mt-4 rounded-md bg-gray-950 p-3 text-sm text-gray-300">
+                  <p className="font-semibold text-white">{file.name}</p>
+                  <p>{formatBytes(file.size)}</p>
+                  {duration !== null && <p>{duration.toFixed(1)} seconds</p>}
+                </div>
+              )}
+
+              {previewUrl && (
+                <div className="mt-4 overflow-hidden rounded-lg bg-black">
+                  <video
+                    src={previewUrl}
+                    controls
+                    muted
+                    playsInline
+                    className="aspect-video w-full object-contain"
+                  />
+                </div>
+              )}
+
+              {durationWarning && (
+                <p className="mt-3 rounded-md bg-yellow-100 px-3 py-2 text-sm text-yellow-900">
+                  {durationWarning}
+                </p>
+              )}
+
+              <label className="mt-5 flex gap-3 rounded-md border border-gray-700 bg-gray-950 p-3 text-sm text-gray-200">
+                <input
+                  type="checkbox"
+                  checked={consent}
+                  onChange={(event) => setConsent(event.target.checked)}
+                  disabled={isUploading}
+                  className="mt-1 h-4 w-4 accent-blue-600"
+                />
+                <span>
+                  Allow DingerZone to retain my uploaded swing video to improve swing analysis. If unchecked, your video will be deleted after 30 days. Your public result link expires after 24 hours.
+                </span>
+              </label>
+
+              {error && (
+                <p className="mt-4 rounded-md bg-red-100 px-3 py-2 text-sm text-red-800">
+                  {error}
+                </p>
+              )}
+
+              <button
+                type="submit"
+                disabled={!file || isUploading}
+                className="mt-5 w-full rounded-md bg-orange-600 px-5 py-3 font-bold text-white transition-colors hover:bg-orange-700 disabled:cursor-not-allowed disabled:bg-gray-600"
+              >
+                {uploadButtonLabel}
+              </button>
+
+              <p className="mt-3 text-center text-xs text-gray-400">
+                For best results, use one side-view clip under {MAX_DURATION_SECONDS} seconds.
+              </p>
+            </form>
+          </div>
+        </section>
+
+        <section className="container mx-auto grid gap-6 px-6 py-10 md:grid-cols-3">
+          {[
+            ['Upload', 'Choose a short swing clip from your phone or computer.'],
+            ['Process', 'DingerZone tracks the swing and generates computer vision output.'],
+            ['Review', 'See the original video, skeleton video, summary, and scorecard.'],
+          ].map(([title, copy]) => (
+            <div key={title} className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+              <h2 className="mb-2 text-xl font-bold text-gray-900">{title}</h2>
+              <p className="text-gray-600">{copy}</p>
+            </div>
+          ))}
+        </section>
+
+        <div className="container mx-auto px-6 pb-10">
+          <Link href="/" className="text-blue-600 hover:text-blue-800">
+            Back to DingerZone
+          </Link>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,7 @@ import Logo from "../../public/assets/images/dingerzone_logo_outline.png";
 
 const navItems = [
   { name: "Home", href: "/#home-section" },
+  { name: "Try It", href: "/try" },
   { name: "About", href: "/#about-section" },
   { name: "FAQ", href: "/#faq-section" },
   { name: "Getting Started", href: "/getting-started" }, // separate page

--- a/src/lib/trialApi.ts
+++ b/src/lib/trialApi.ts
@@ -1,0 +1,145 @@
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  'https://jhmyrcpav9.execute-api.us-east-1.amazonaws.com/dev';
+
+const TRIAL_START_PATH = '/api/trial-upload/start';
+const TRIAL_COMPLETE_PATH = '/api/trial-upload/complete';
+const SHARED_DETAILS_PATH = '/api/shared-video-details';
+
+export const getVideoContentType = (file: File) => {
+  if (file.type.startsWith('video/')) return file.type;
+
+  const extension = file.name.split('.').pop()?.toLowerCase();
+  if (extension === 'mov' || extension === 'qt') return 'video/quicktime';
+  if (extension === 'm4v') return 'video/x-m4v';
+  if (extension === 'mp4') return 'video/mp4';
+
+  return null;
+};
+
+export const isVideoFile = (file: File) => Boolean(getVideoContentType(file));
+
+export interface TrialUploadStartResponse {
+  trialId: string;
+  videoId: string;
+  shareId: string;
+  upload: {
+    url: string;
+    fields: Record<string, string>;
+  };
+  publicExpiresAt: string;
+  modelImprovementConsent: boolean;
+  retentionExpiresAt: string | null;
+  maxUploadBytes: number;
+}
+
+export interface TrialUploadCompleteResponse {
+  trialId: string;
+  videoId: string;
+  shareId: string;
+  publicExpiresAt: string;
+  sharePath: string;
+  status: 'PROCESSING' | string;
+}
+
+export interface ScorecardMetric {
+  score: number;
+  description: string;
+}
+
+export interface TrialVideoDetails {
+  videoUrl: string;
+  skeletonUrl: string | null;
+  thumbnailUrl: string | null;
+  playerName: string;
+  uploadDate: string;
+  description: string;
+  videoStatus: string | null;
+  aiSummary: string | null;
+  aiScorecard: Record<string, ScorecardMetric> | null;
+  expirationTime: string;
+  publicExpiresAt?: string;
+  modelImprovementConsent?: boolean | null;
+  retentionExpiresAt?: string | null;
+}
+
+const parseJsonResponse = async <T>(response: Response): Promise<T> => {
+  const payload = await response.json().catch(() => null);
+  const parsedPayload =
+    payload && typeof payload.body === 'string' ? JSON.parse(payload.body) : payload;
+
+  if (!response.ok) {
+    const message =
+      parsedPayload?.error || `Request failed with status ${response.status}`;
+    throw new Error(message);
+  }
+
+  return parsedPayload as T;
+};
+
+export const startTrialUpload = async ({
+  file,
+  modelImprovementConsent,
+  source = 'marketing',
+}: {
+  file: File;
+  modelImprovementConsent: boolean;
+  source?: string;
+}) => {
+  const response = await fetch(TRIAL_START_PATH, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contentType: getVideoContentType(file) || 'video/mp4',
+      contentLength: file.size,
+      modelImprovementConsent,
+      source,
+    }),
+  });
+
+  return parseJsonResponse<TrialUploadStartResponse>(response);
+};
+
+export const uploadTrialFile = async ({
+  file,
+  startResponse,
+}: {
+  file: File;
+  startResponse: TrialUploadStartResponse;
+}) => {
+  const formData = new FormData();
+
+  Object.entries(startResponse.upload.fields).forEach(([key, value]) => {
+    formData.append(key, value);
+  });
+  formData.append('file', file);
+
+  const response = await fetch(startResponse.upload.url, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error(`S3 upload failed with status ${response.status}`);
+  }
+};
+
+export const completeTrialUpload = async (trialId: string) => {
+  const response = await fetch(TRIAL_COMPLETE_PATH, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ trialId }),
+  });
+
+  return parseJsonResponse<TrialUploadCompleteResponse>(response);
+};
+
+export const fetchTrialVideoDetails = async (shareId: string) => {
+  const response = await fetch(SHARED_DETAILS_PATH, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ shareId }),
+  });
+
+  return parseJsonResponse<TrialVideoDetails>(response);
+};


### PR DESCRIPTION
## Summary
- add public /try upload flow for one-off marketing trial swing uploads
- proxy trial upload and shared-details API calls through same-origin Next routes
- add /try/[shareId] result page with polling, original/computer-vision video toggle, summary feedback, and scorecard details
- add homepage/header entry points into the trial flow

## Verification
- npm run build
- trial upload smoke tested against dev API after extractor deployment
- new skeleton output verified as browser-playable H.264/yuv420p