### PR TITLE
Add beta labels to trial experience

### DIFF
--- a/src/app/try/[shareId]/page.tsx
+++ b/src/app/try/[shareId]/page.tsx
@@ -14,6 +14,12 @@ import {
 
 const POLL_INTERVAL_MS = 10000;
 
+const betaAnalysisNotes = [
+  'AI summaries, live swing metrics, and scorecard values are beta outputs and may not capture every detail of the swing.',
+  'Use these results as directional coaching context alongside your own review of the video.',
+  'Video angle, lighting, occlusion, frame rate, and clip length can affect the computer vision output.',
+];
+
 const metricLabels: Record<string, string> = {
   handPath: 'Hand Path',
   stride: 'Stride',
@@ -150,7 +156,12 @@ const LiveSwingMetrics = ({
     <div className="mt-4 rounded-lg border border-gray-800 bg-gray-900 p-4">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h2 className="text-lg font-bold">Live Swing Metrics</h2>
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-lg font-bold">Live Swing Metrics</h2>
+            <span className="rounded-full border border-orange-400/50 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-orange-300">
+              Beta
+            </span>
+          </div>
           <p className="mt-1 text-sm text-gray-400">
             Synced to playback at a suggested 10 samples per second.
           </p>
@@ -341,9 +352,14 @@ export default function TrialResultPage() {
         <section className="border-b border-gray-800 bg-gray-900">
           <div className="container mx-auto flex flex-col gap-4 px-6 py-6 md:flex-row md:items-center md:justify-between">
             <div>
-              <p className="text-sm font-semibold uppercase tracking-wide text-orange-300">
-                DingerZone trial result
-              </p>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-full bg-orange-500 px-3 py-1 text-xs font-bold uppercase tracking-wide text-gray-950">
+                  Beta
+                </span>
+                <p className="text-sm font-semibold uppercase tracking-wide text-orange-300">
+                  DingerZone trial result
+                </p>
+              </div>
               <h1 className="mt-1 text-3xl font-bold">Swing Analysis</h1>
               <p className="mt-2 text-sm text-gray-300">
                 {details?.publicExpiresAt || details?.expirationTime
@@ -402,6 +418,20 @@ export default function TrialResultPage() {
           {details && (
             <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
               <section>
+                <div className="mb-4 rounded-lg border border-orange-400/40 bg-orange-500/10 p-4 text-sm leading-6 text-orange-50">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <h2 className="font-bold text-orange-200">Beta analysis notice</h2>
+                      <p className="mt-1">
+                        DingerZone is still tuning this AI analysis and swing metric calculation system. Treat the feedback as helpful direction, not a final evaluation.
+                      </p>
+                    </div>
+                    <span className="inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-full border border-orange-300/50 px-3 py-1 text-center text-xs font-semibold uppercase tracking-wide text-orange-200 sm:self-center">
+                      In development
+                    </span>
+                  </div>
+                </div>
+
                 <div className="mb-4 rounded-lg border border-gray-800 bg-gray-900 p-4">
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
@@ -505,9 +535,25 @@ export default function TrialResultPage() {
               </section>
 
               <section className="space-y-4">
+                <div className="rounded-lg border border-blue-800 bg-blue-950 p-5 text-blue-100">
+                  <h2 className="text-lg font-bold">How to read beta analysis</h2>
+                  <div className="mt-3 space-y-2">
+                    {betaAnalysisNotes.map((note) => (
+                      <p key={note} className="text-sm leading-6 text-blue-100">
+                        {note}
+                      </p>
+                    ))}
+                  </div>
+                </div>
+
                 <div className="rounded-lg border border-gray-800 bg-gray-900 p-5">
                   <div className="flex items-center justify-between gap-4">
-                    <h2 className="text-xl font-bold">Overall</h2>
+                    <div>
+                      <h2 className="text-xl font-bold">Overall</h2>
+                      <p className="mt-1 text-xs font-semibold uppercase tracking-wide text-orange-300">
+                        Beta score
+                      </p>
+                    </div>
                     <span className="text-lg font-bold text-orange-300">
                       {averageScore ? `${averageScore.toFixed(1)}/5.0` : 'Pending'}
                     </span>
@@ -526,7 +572,12 @@ export default function TrialResultPage() {
 
                 {summaryFeedback && (
                   <div className="rounded-lg border border-gray-800 bg-gray-900 p-5">
-                    <h2 className="text-xl font-bold">Summary Feedback</h2>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2 className="text-xl font-bold">Summary Feedback</h2>
+                      <span className="rounded-full border border-orange-400/50 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-orange-300">
+                        Beta AI
+                      </span>
+                    </div>
                     <p className="mt-3 whitespace-pre-line text-sm leading-6 text-gray-300">
                       {summaryFeedback}
                     </p>
@@ -540,6 +591,9 @@ export default function TrialResultPage() {
                         <div className="flex items-center justify-between gap-4">
                           <div className="relative flex items-center gap-2">
                             <h3 className="font-bold">{formatMetricLabel(key)}</h3>
+                            <span className="rounded-full border border-gray-600 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-300">
+                              Beta
+                            </span>
                             <button
                               type="button"
                               className="group flex h-5 w-5 items-center justify-center rounded-full border border-gray-500 text-xs font-bold text-gray-300 transition-colors hover:border-blue-300 hover:text-blue-200"

--- a/src/app/try/page.tsx
+++ b/src/app/try/page.tsx
@@ -46,9 +46,15 @@ const filmingTips = [
 
 const processSteps = [
   ['1', 'Upload', 'Choose one short swing clip.'],
-  ['2', 'Analyze', 'AI maps movement and generates feedback.'],
-  ['3', 'Review', 'See the overlay, notes, and scorecard.'],
+  ['2', 'Analyze', 'Beta AI maps movement and generates feedback.'],
+  ['3', 'Review', 'See the overlay, notes, and beta scorecard.'],
   ['4', 'Share', 'Copy the 24-hour public link.'],
+];
+
+const betaNotes = [
+  'AI feedback and swing metric calculations are in beta and may change as the model improves.',
+  'Use the scorecard as coaching context, not a definitive grade or medical/training diagnosis.',
+  'Short, side-view clips with the full hitter visible produce the most reliable analysis.',
 ];
 
 const formatBytes = (bytes: number) => {
@@ -299,15 +305,26 @@ export default function TrialUploadPage() {
         <section className="bg-gray-950 text-white">
           <div className="container mx-auto grid gap-8 px-4 py-8 sm:px-6 lg:grid-cols-[minmax(0,0.95fr)_minmax(420px,0.75fr)] lg:items-start lg:py-10 xl:gap-10">
             <div className="min-w-0 lg:col-start-1 lg:row-start-1">
-              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-orange-300">
-                Free swing analysis preview
-              </p>
+              <div className="mb-2 flex flex-wrap items-center gap-2">
+                <span className="rounded-full bg-orange-500 px-3 py-1 text-xs font-bold uppercase tracking-wide text-gray-950">
+                  Beta
+                </span>
+                <p className="text-xs font-semibold uppercase tracking-wide text-orange-300">
+                  Free swing analysis preview
+                </p>
+              </div>
               <h1 className="text-4xl font-bold leading-tight sm:text-5xl">
                 Get AI feedback you can share.
               </h1>
               <p className="mt-4 max-w-2xl text-lg leading-8 text-gray-200">
-                Try DingerZone with a short baseball swing clip. We process it into a computer-vision overlay, coaching-style feedback, and a scorecard-style breakdown.
+                Try DingerZone with a short baseball swing clip. We process it into a computer-vision overlay, coaching-style feedback, and a beta scorecard-style breakdown.
               </p>
+              <div className="mt-5 rounded-lg border border-orange-400/40 bg-orange-500/10 p-4 text-sm leading-6 text-orange-50">
+                <p className="font-semibold text-orange-200">Beta analysis notice</p>
+                <p className="mt-1">
+                  This preview is built to help you explore feedback quickly while we continue tuning the computer vision, AI summary, and swing metric calculations.
+                </p>
+              </div>
             </div>
 
             <form
@@ -458,6 +475,22 @@ export default function TrialUploadPage() {
                   </div>
                 ))}
               </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="container mx-auto px-6 pt-10">
+          <div className="rounded-lg border border-blue-200 bg-blue-50 p-5 text-blue-950">
+            <h2 className="text-xl font-bold">What to expect from beta feedback</h2>
+            <div className="mt-4 grid gap-3 md:grid-cols-3">
+              {betaNotes.map((note) => (
+                <div
+                  key={note}
+                  className="rounded-md border border-blue-100 bg-white p-4 text-sm leading-6 text-gray-700"
+                >
+                  {note}
+                </div>
+              ))}
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- Add beta labeling and expectation-setting copy to the /try upload experience without changing the production upload layout
- Add beta notices to trial result pages, including live swing metrics, summary feedback, and scorecard sections
- Preserve the production liveMetrics playback-synced swing metric behavior

## Test
- npm run build