### PR TITLE
Add Vercel analytics tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "dingerzone_web",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "axios": "^1.9.0",
         "next": "^16.0.8",
         "react": "^19.0.0",
@@ -1305,6 +1307,86 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "axios": "^1.9.0",
     "next": "^16.0.8",
     "react": "^19.0.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@
 import "./globals.css";
 import type { ReactNode } from 'react';
 import { Inter } from 'next/font/google';
+import { Analytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -30,7 +32,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           rel="stylesheet"
         /> */}
       </head>
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        {children}
+        <Analytics />
+        <SpeedInsights />
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import Footer from '../components/Footer';
 import Image from 'next/image';
 import Link from 'next/link';
 import React, { useState, useEffect } from 'react';
+import { trackAnalyticsEvent } from '../lib/analytics';
 
 export default function LandingPage() {
   const [activeTab, setActiveTab] = useState<'Player' | 'Parent' | 'Coach'>('Player');
@@ -87,6 +88,10 @@ export default function LandingPage() {
   ];
 
   const toggleFaq = (index: number) => {
+    trackAnalyticsEvent('faq_toggle', {
+      question: faqs[index]?.question || `faq_${index}`,
+      expanded: openFaq !== index,
+    });
     setOpenFaq(openFaq === index ? null : index);
   };
 
@@ -133,18 +138,33 @@ export default function LandingPage() {
                 <Link
                   href="/examples"
                   className="inline-flex items-center justify-center rounded-md border border-white bg-white/10 px-6 py-3 text-base font-bold text-white shadow-lg transition-colors hover:bg-white/20"
+                  onClick={() =>
+                    trackAnalyticsEvent('cta_click', {
+                      location: 'hero',
+                      label: 'examples',
+                    })
+                  }
                 >
                   See Example Analysis
                 </Link>
                 <Link
                   href="/try"
                   className="inline-flex items-center justify-center rounded-md bg-orange-600 px-6 py-3 text-base font-bold text-white shadow-lg transition-colors hover:bg-orange-700"
+                  onClick={() =>
+                    trackAnalyticsEvent('cta_click', {
+                      location: 'hero',
+                      label: 'try_upload',
+                    })
+                  }
                 >
                   Try a Free Swing Upload
                 </Link>
                 <a
                   href="https://apple.co/3Js2maF"
                   className="inline-flex items-center justify-center rounded-md bg-white px-6 py-3 text-base font-bold text-blue-700 shadow-lg transition-colors hover:bg-gray-100"
+                  onClick={() =>
+                    trackAnalyticsEvent('app_store_click', { location: 'hero' })
+                  }
                 >
                   Download Now
                 </a>
@@ -200,7 +220,10 @@ export default function LandingPage() {
             {tabs.map((tab) => (
               <button
                 key={tab}
-                onClick={() => setActiveTab(tab)}
+                onClick={() => {
+                  trackAnalyticsEvent('audience_tab_click', { tab });
+                  setActiveTab(tab);
+                }}
                 className={`flex items-center px-4 py-2 rounded-full font-semibold text-sm transition-colors ${
                   activeTab === tab
                     ? 'bg-blue-600 text-white'
@@ -255,6 +278,9 @@ export default function LandingPage() {
               <a
                 href="https://apple.co/3Js2maF"
                 className="inline-block"
+                onClick={() =>
+                  trackAnalyticsEvent('app_store_click', { location: 'benefits' })
+                }
               >
                 <Image
                   src="/assets/images/appstore_black.svg"
@@ -337,6 +363,9 @@ export default function LandingPage() {
             <a
               href="mailto:feedback@dingerzone.ai"
               className="text-blue-600 hover:underline"
+              onClick={() =>
+                trackAnalyticsEvent('contact_click', { location: 'contact_section' })
+              }
             >
               feedback@dingerzone.ai
             </a>

--- a/src/app/shared/[shareId]/page.tsx
+++ b/src/app/shared/[shareId]/page.tsx
@@ -10,6 +10,7 @@ import {
   fetchTrialVideoDetails,
   type LiveMetricSample,
 } from '../../../lib/trialApi';
+import { trackAnalyticsEvent } from '../../../lib/analytics';
 
 interface VideoDetails {
   videoUrl: string;
@@ -291,6 +292,12 @@ export default function SharedVideoPage() {
           <a
             href="https://www.dingerzone.com"
             className="inline-block px-6 py-3 bg-blue-600 text-white rounded-3xl hover:bg-blue-800"
+            onClick={() =>
+              trackAnalyticsEvent('cta_click', {
+                location: 'shared_video_error',
+                label: 'back_to_dingerzone',
+              })
+            }
           >
             Back to DingerZone
           </a>
@@ -360,6 +367,10 @@ export default function SharedVideoPage() {
                 <span className="text-sm mr-2">Original</span>
                 <Switch
                   onChange={() => {
+                    trackAnalyticsEvent('video_mode_toggle', {
+                      location: 'shared_video',
+                      mode: isSkeleton ? 'original' : 'computer_vision',
+                    });
                     setIsSkeleton(!isSkeleton);
                     setVideoPlaybackError(null);
                     setHasVideoStarted(false);
@@ -394,6 +405,10 @@ export default function SharedVideoPage() {
                     setVideoTime(event.currentTarget.currentTime || 0);
                   }}
                   onPlay={(event) => {
+                    trackAnalyticsEvent('video_play', {
+                      location: 'shared_video',
+                      mode: isSkeleton ? 'computer_vision' : 'original',
+                    });
                     setHasVideoStarted(true);
                     setVideoPlaybackError(null);
                     watchForRenderedVideoFrame(event.currentTarget);
@@ -409,6 +424,10 @@ export default function SharedVideoPage() {
                     setVideoTime(event.currentTarget.currentTime || 0);
                   }}
                   onError={(e) => {
+                    trackAnalyticsEvent('video_error', {
+                      location: 'shared_video',
+                      mode: isSkeleton ? 'computer_vision' : 'original',
+                    });
                     console.error('Video playback error:', e);
                     setVideoPlaybackError(
                       'Video playback is unavailable in this browser, but the swing analysis is still available below.'

--- a/src/app/try/[shareId]/page.tsx
+++ b/src/app/try/[shareId]/page.tsx
@@ -11,6 +11,7 @@ import {
   TrialVideoDetails,
   fetchTrialVideoDetails,
 } from '../../../lib/trialApi';
+import { trackAnalyticsEvent } from '../../../lib/analytics';
 
 const POLL_INTERVAL_MS = 10000;
 const FEEDBACK_EMAIL = 'feedback@dingerzone.ai';
@@ -353,6 +354,7 @@ export default function TrialResultPage() {
   const handleShare = async () => {
     const shareUrl = window.location.href;
     setShareStatus('idle');
+    trackAnalyticsEvent('share_click', { location: 'trial_result' });
 
     try {
       if (navigator.share) {
@@ -362,17 +364,30 @@ export default function TrialResultPage() {
           url: shareUrl,
         });
         setShareStatus('shared');
+        trackAnalyticsEvent('share_success', {
+          location: 'trial_result',
+          method: 'native',
+        });
         return;
       }
 
       await navigator.clipboard.writeText(shareUrl);
       setShareStatus('copied');
+      trackAnalyticsEvent('share_success', {
+        location: 'trial_result',
+        method: 'clipboard',
+      });
     } catch {
       try {
         await navigator.clipboard.writeText(shareUrl);
         setShareStatus('copied');
+        trackAnalyticsEvent('share_success', {
+          location: 'trial_result',
+          method: 'clipboard_fallback',
+        });
       } catch {
         setShareStatus('error');
+        trackAnalyticsEvent('share_error', { location: 'trial_result' });
       }
     }
   };
@@ -382,6 +397,12 @@ export default function TrialResultPage() {
     if (!shareId || !feedbackCanSubmit) return;
 
     setFeedbackError(null);
+    trackAnalyticsEvent('trial_feedback_submit', {
+      sentiment: feedbackSentiment,
+      followUpConsent,
+      hasContactEmail: Boolean(contactEmail.trim()),
+      hasContactName: Boolean(contactName.trim()),
+    });
 
     try {
       const playbackSeconds = Number.isFinite(videoTime) ? videoTime.toFixed(2) : 'Unknown';
@@ -410,8 +431,12 @@ export default function TrialResultPage() {
         subject
       )}&body=${encodeURIComponent(body)}`;
       setFeedbackStatus('opened');
+      trackAnalyticsEvent('trial_feedback_email_opened', {
+        sentiment: feedbackSentiment,
+      });
     } catch {
       setFeedbackStatus('error');
+      trackAnalyticsEvent('trial_feedback_error');
       setFeedbackError(`Unable to open your email app. Please email ${FEEDBACK_EMAIL}.`);
     }
   };
@@ -463,6 +488,12 @@ export default function TrialResultPage() {
               <Link
                 href="/try"
                 className="inline-flex min-h-12 items-center justify-center gap-2 rounded-full bg-orange-600 px-6 py-3 font-bold text-white hover:bg-orange-700"
+                onClick={() =>
+                  trackAnalyticsEvent('cta_click', {
+                    location: 'trial_result',
+                    label: 'analyze_another',
+                  })
+                }
               >
                 <RepeatOutlineIcon />
                 Analyze Another Swing
@@ -504,6 +535,9 @@ export default function TrialResultPage() {
                       <button
                         type="button"
                         onClick={() => {
+                          trackAnalyticsEvent('trial_feedback_toggle', {
+                            expanded: !showFeedbackForm,
+                          });
                           setShowFeedbackForm((current) => !current);
                           setFeedbackStatus((current) => (current === 'opened' ? 'idle' : current));
                           setFeedbackError(null);
@@ -657,6 +691,10 @@ export default function TrialResultPage() {
                         type="button"
                         onClick={() => {
                           setVideoError(null);
+                          trackAnalyticsEvent('video_mode_toggle', {
+                            location: 'trial_result',
+                            mode: showSkeleton ? 'original' : 'computer_vision',
+                          });
                           setShowSkeleton((current) => !current);
                         }}
                         disabled={!hasSkeleton}
@@ -693,10 +731,22 @@ export default function TrialResultPage() {
                         setVideoDuration(event.currentTarget.duration || null);
                         setVideoTime(event.currentTarget.currentTime || 0);
                       }}
+                      onPlay={() => {
+                        trackAnalyticsEvent('video_play', {
+                          location: 'trial_result',
+                          mode: showSkeleton && hasSkeleton ? 'computer_vision' : 'original',
+                          processed: isProcessed,
+                        });
+                      }}
                       onTimeUpdate={(event) => {
                         setVideoTime(event.currentTarget.currentTime || 0);
                       }}
                       onError={(event) => {
+                        trackAnalyticsEvent('video_error', {
+                          location: 'trial_result',
+                          mode: showSkeleton && hasSkeleton ? 'computer_vision' : 'original',
+                          processed: isProcessed,
+                        });
                         const mediaError = event.currentTarget.error;
                         console.error('Video playback error', {
                           mode: showSkeleton ? 'skeleton' : 'original',

--- a/src/app/try/page.tsx
+++ b/src/app/try/page.tsx
@@ -12,6 +12,7 @@ import {
   completeTrialUpload,
   isVideoFile,
 } from '../../lib/trialApi';
+import { trackAnalyticsEvent } from '../../lib/analytics';
 
 const MAX_DURATION_SECONDS = 10;
 const FALLBACK_MAX_UPLOAD_BYTES = 75 * 1024 * 1024;
@@ -198,12 +199,19 @@ export default function TrialUploadPage() {
 
     if (!selectedFile) return;
 
+    trackAnalyticsEvent('trial_file_selected', {
+      sizeMb: Number((selectedFile.size / (1024 * 1024)).toFixed(1)),
+      type: selectedFile.type || 'unknown',
+    });
+
     if (!isVideoFile(selectedFile)) {
+      trackAnalyticsEvent('trial_file_rejected', { reason: 'invalid_type' });
       setError('Please choose a video file.');
       return;
     }
 
     if (selectedFile.size > maxUploadBytes) {
+      trackAnalyticsEvent('trial_file_rejected', { reason: 'too_large' });
       setError(`Please choose a video under ${formatBytes(maxUploadBytes)}.`);
       return;
     }
@@ -211,12 +219,16 @@ export default function TrialUploadPage() {
     try {
       const videoDuration = await getVideoDuration(selectedFile);
       setDuration(videoDuration);
+      trackAnalyticsEvent('trial_file_duration_loaded', {
+        durationSeconds: Number(videoDuration.toFixed(1)),
+      });
       if (videoDuration > MAX_DURATION_SECONDS) {
         setDurationWarning(
           `This clip is ${videoDuration.toFixed(1)} seconds. Short clips under ${MAX_DURATION_SECONDS} seconds process best.`
         );
       }
     } catch {
+      trackAnalyticsEvent('trial_file_duration_error');
       setDurationWarning('We could not verify the clip length, but you can still try the upload.');
     }
   };
@@ -237,6 +249,11 @@ export default function TrialUploadPage() {
 
     setIsUploading(true);
     setError(null);
+    trackAnalyticsEvent('trial_upload_started', {
+      consent,
+      sizeMb: Number((file.size / (1024 * 1024)).toFixed(1)),
+      durationSeconds: duration ? Number(duration.toFixed(1)) : 0,
+    });
 
     try {
       setStep('starting');
@@ -252,8 +269,13 @@ export default function TrialUploadPage() {
       setStep('completing');
       const completeResponse = await completeTrialUpload(startResponse.trialId);
 
+      trackAnalyticsEvent('trial_upload_completed', {
+        consent,
+        durationSeconds: duration ? Number(duration.toFixed(1)) : 0,
+      });
       router.push(`/try/${completeResponse.shareId}`);
     } catch (uploadError) {
+      trackAnalyticsEvent('trial_upload_failed');
       setError(
         uploadError instanceof Error
           ? uploadError.message
@@ -267,6 +289,7 @@ export default function TrialUploadPage() {
   const handleShareTryPage = async () => {
     const shareUrl = `${window.location.origin}/try`;
     setTryPageShareStatus('idle');
+    trackAnalyticsEvent('share_click', { location: 'try_page' });
 
     try {
       if (navigator.share) {
@@ -276,17 +299,30 @@ export default function TrialUploadPage() {
           url: shareUrl,
         });
         setTryPageShareStatus('shared');
+        trackAnalyticsEvent('share_success', {
+          location: 'try_page',
+          method: 'native',
+        });
         return;
       }
 
       await navigator.clipboard.writeText(shareUrl);
       setTryPageShareStatus('copied');
+      trackAnalyticsEvent('share_success', {
+        location: 'try_page',
+        method: 'clipboard',
+      });
     } catch {
       try {
         await navigator.clipboard.writeText(shareUrl);
         setTryPageShareStatus('copied');
+        trackAnalyticsEvent('share_success', {
+          location: 'try_page',
+          method: 'clipboard_fallback',
+        });
       } catch {
         setTryPageShareStatus('error');
+        trackAnalyticsEvent('share_error', { location: 'try_page' });
       }
     }
   };
@@ -323,6 +359,12 @@ export default function TrialUploadPage() {
                 <Link
                   href="/examples"
                   className="inline-flex min-h-11 items-center justify-center rounded-md border border-blue-300 px-5 py-3 text-sm font-bold text-blue-100 transition-colors hover:bg-blue-500/10"
+                  onClick={() =>
+                    trackAnalyticsEvent('cta_click', {
+                      location: 'try_page',
+                      label: 'examples',
+                    })
+                  }
                 >
                   See sample results first
                 </Link>
@@ -400,6 +442,11 @@ export default function TrialUploadPage() {
                     muted
                     playsInline
                     className="aspect-video w-full object-contain"
+                    onPlay={() =>
+                      trackAnalyticsEvent('video_play', {
+                        location: 'try_upload_preview',
+                      })
+                    }
                   />
                 </div>
               )}

--- a/src/components/ExampleResultView.tsx
+++ b/src/components/ExampleResultView.tsx
@@ -7,6 +7,7 @@ import {
   LiveMetricSample,
   ScorecardMetric,
 } from '../lib/trialApi';
+import { trackAnalyticsEvent } from '../lib/analytics';
 
 const metricLabels: Record<string, string> = {
   handPath: 'Hand Path',
@@ -116,6 +117,11 @@ export default function ExampleResultView({ example }: { example: ExampleAnalysi
                 type="button"
                 onClick={() => {
                   setVideoError(null);
+                  trackAnalyticsEvent('video_mode_toggle', {
+                    location: 'example_result',
+                    example: example.slug,
+                    mode: showSkeleton ? 'original' : 'computer_vision',
+                  });
                   setShowSkeleton((current) => !current);
                 }}
                 disabled={!hasSkeleton}
@@ -151,10 +157,22 @@ export default function ExampleResultView({ example }: { example: ExampleAnalysi
                 setVideoDuration(event.currentTarget.duration || null);
                 setVideoTime(event.currentTarget.currentTime || 0);
               }}
+              onPlay={() => {
+                trackAnalyticsEvent('video_play', {
+                  location: 'example_result',
+                  example: example.slug,
+                  mode: showSkeleton && hasSkeleton ? 'computer_vision' : 'original',
+                });
+              }}
               onTimeUpdate={(event) => {
                 setVideoTime(event.currentTarget.currentTime || 0);
               }}
               onError={() => {
+                trackAnalyticsEvent('video_error', {
+                  location: 'example_result',
+                  example: example.slug,
+                  mode: showSkeleton && hasSkeleton ? 'computer_vision' : 'original',
+                });
                 setVideoError(
                   showSkeleton
                     ? 'Computer vision video is not playable yet. Try switching back to Original, then retry in a moment.'

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,9 +2,11 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { trackAnalyticsEvent } from "../lib/analytics";
 
 export default function Footer() {
   const getStartedClick = () => {
+    trackAnalyticsEvent("contact_click", { location: "footer" });
     window.location.href = `mailto:feedback@dingerzone.ai?subject=${encodeURIComponent(
       "DingerZone Subscription"
     )}`;
@@ -15,7 +17,13 @@ export default function Footer() {
       <div className="container mx-auto px-6 flex flex-col md:flex-row justify-between items-center">
         <p className="text-gray-600">© DingerZone 2025</p>
         <div className="flex flex-wrap gap-4 mt-4 md:mt-0 items-center">
-          <Link href="/getting-started" className="text-gray-600 hover:text-gray-900">
+          <Link
+            href="/getting-started"
+            className="text-gray-600 hover:text-gray-900"
+            onClick={() =>
+              trackAnalyticsEvent("footer_link_click", { label: "getting_started" })
+            }
+          >
             Getting Started Guide
           </Link>
           <a href="/privacy" className="text-gray-600 hover:text-gray-900">
@@ -27,6 +35,7 @@ export default function Footer() {
           <a
             href="https://www.apple.com/legal/internet-services/itunes/dev/stdeula/"
             className="text-gray-600 hover:text-gray-900"
+            onClick={() => trackAnalyticsEvent("footer_link_click", { label: "eula" })}
           >
             EULA
           </a>
@@ -36,7 +45,13 @@ export default function Footer() {
           >
             Contact
           </button>
-          <a href="https://apple.co/3Js2maF" className="inline-block">
+          <a
+            href="https://apple.co/3Js2maF"
+            className="inline-block"
+            onClick={() =>
+              trackAnalyticsEvent("app_store_click", { location: "footer" })
+            }
+          >
             <Image
               src="/assets/images/appstore_black.svg"
               alt="Download on the App Store"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Logo from "../../public/assets/images/dingerzone_logo_outline.png";
+import { trackAnalyticsEvent } from "../lib/analytics";
 
 const navItems = [
   { name: "Home", href: "/#home-section" },
@@ -24,6 +25,7 @@ export default function Header() {
   };
 
   const handleFeedbackClick = () => {
+    trackAnalyticsEvent("contact_click", { location: "header" });
     window.location.href = "mailto:feedback@dingerzone.ai";
   };
 
@@ -32,6 +34,11 @@ export default function Header() {
     href: string,
     closeMenu: boolean
   ) => {
+    trackAnalyticsEvent("navigation_click", {
+      label: href,
+      location: closeMenu ? "mobile_header" : "desktop_header",
+    });
+
     // Only care about in-page anchors like "/#about-section"
     if (href.startsWith("/#")) {
       const id = href.substring(2); // "/#faq-section" -> "faq-section"
@@ -100,7 +107,13 @@ export default function Header() {
           >
             Contact Us
           </button>
-          <a href="https://apple.co/3Js2maF" className="ml-4 inline-block">
+          <a
+            href="https://apple.co/3Js2maF"
+            className="ml-4 inline-block"
+            onClick={() =>
+              trackAnalyticsEvent("app_store_click", { location: "desktop_header" })
+            }
+          >
             <Image
               src="/assets/images/appstore_black.svg"
               alt="Download on the App Store"
@@ -174,7 +187,13 @@ export default function Header() {
           >
             Contact Us
           </button>
-          <a href="https://apple.co/3Js2maF" className="inline-block">
+          <a
+            href="https://apple.co/3Js2maF"
+            className="inline-block"
+            onClick={() =>
+              trackAnalyticsEvent("app_store_click", { location: "mobile_header" })
+            }
+          >
             <Image
               src="/assets/images/appstore_black.svg"
               alt="Download on the App Store"

--- a/src/components/SharePageButton.tsx
+++ b/src/components/SharePageButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { trackAnalyticsEvent } from '../lib/analytics';
 
 const ShareIcon = () => (
   <svg
@@ -33,22 +34,36 @@ export default function SharePageButton({
   const handleShare = async () => {
     const url = window.location.href;
     setStatus('idle');
+    trackAnalyticsEvent('share_click', { location: 'example_page' });
 
     try {
       if (navigator.share) {
         await navigator.share({ title, text, url });
         setStatus('shared');
+        trackAnalyticsEvent('share_success', {
+          location: 'example_page',
+          method: 'native',
+        });
         return;
       }
 
       await navigator.clipboard.writeText(url);
       setStatus('copied');
+      trackAnalyticsEvent('share_success', {
+        location: 'example_page',
+        method: 'clipboard',
+      });
     } catch {
       try {
         await navigator.clipboard.writeText(url);
         setStatus('copied');
+        trackAnalyticsEvent('share_success', {
+          location: 'example_page',
+          method: 'clipboard_fallback',
+        });
       } catch {
         setStatus('error');
+        trackAnalyticsEvent('share_error', { location: 'example_page' });
       }
     }
   };

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { track } from '@vercel/analytics';
+
+type AnalyticsProperties = Record<string, string | number | boolean>;
+
+export const trackAnalyticsEvent = (
+  name: string,
+  properties: AnalyticsProperties = {}
+) => {
+  try {
+    track(name, properties);
+  } catch {
+    // Analytics should never interrupt core site interactions.
+  }
+};


### PR DESCRIPTION
## Summary
- add Vercel Web Analytics and Speed Insights to the app layout
- add a small client-side analytics helper
- track key engagement events for app store links, contact links, CTAs, sharing, uploads, feedback, and video playback

## Verification
- npm run build
- git diff --check